### PR TITLE
Add views summary data for cases and parties

### DIFF
--- a/db/migrate/20210727172748_update_case_stats_to_version_3.rb
+++ b/db/migrate/20210727172748_update_case_stats_to_version_3.rb
@@ -1,5 +1,5 @@
 class UpdateCaseStatsToVersion3 < ActiveRecord::Migration[6.1]
   def change
-    update_view :case_stats, version: 3, revert_to_version: 2
+    update_view :case_stats, version: 3, revert_to_version: 2, materialized: true
   end
 end

--- a/db/migrate/20211001151213_update_case_stats_to_version_4.rb
+++ b/db/migrate/20211001151213_update_case_stats_to_version_4.rb
@@ -1,0 +1,7 @@
+class UpdateCaseStatsToVersion4 < ActiveRecord::Migration[6.1]
+  def change
+    drop_view :case_stats, revert_to_version: 3
+    create_view :case_stats, materialized: true, version: 4
+    add_index :case_stats, :court_case_id
+  end
+end

--- a/db/migrate/20211001151706_create_party_stats.rb
+++ b/db/migrate/20211001151706_create_party_stats.rb
@@ -1,0 +1,6 @@
+class CreatePartyStats < ActiveRecord::Migration[6.1]
+  def change
+    create_view :party_stats, materialized: true
+    add_index :party_stats, :party_id
+  end
+end

--- a/db/views/case_stats_v04.sql
+++ b/db/views/case_stats_v04.sql
@@ -1,0 +1,66 @@
+SELECT
+  court_cases.id as court_case_id,
+  (closed_on - filed_on) AS length_of_case_in_days,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      counts
+    WHERE
+      court_cases.id = counts.court_case_id
+  ) AS counts_count,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      case_parties
+      JOIN parties ON case_parties.party_id = parties.id
+      JOIN party_types ON parties.party_type_id = party_types.id
+    WHERE
+      court_cases.id = case_parties.court_case_id
+      AND party_types.name = 'defendant'
+  ) AS defendant_count,
+  (
+    CASE
+      WHEN (
+        SELECT
+          COUNT(*)
+        FROM
+          docket_events
+        WHERE
+          docket_events.court_case_id = court_cases.id
+      ) > 0 THEN TRUE
+      ELSE FALSE
+    END
+  ) AS is_tax_intercepted,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      docket_events
+      JOIN docket_event_types ON docket_events.docket_event_type_id = docket_event_types.id
+    WHERE
+      court_case_id = court_cases.id
+      AND docket_event_types.code IN(
+        'WAI$',
+        'BWIFAP',
+        'BWIFA',
+        'BWIFC',
+        'BWIAR',
+        'BWIAA',
+        'BWICA',
+        'BWIFAR',
+        'BWIFAA',
+        'BWIFP',
+        'BWIMW',
+        'BWIR8',
+        'BWIS',
+        'BWIS$',
+        'WAI',
+        'WAIMV',
+        'WAIMW',
+        'BWIFAR'
+      )
+  ) AS warrants_count
+FROM
+  court_cases

--- a/db/views/party_stats_v01.sql
+++ b/db/views/party_stats_v01.sql
@@ -1,0 +1,113 @@
+SELECT
+  parties.id AS party_id,(
+    SELECT
+      COUNT(*)
+    FROM
+      case_parties
+    WHERE
+      party_id = parties.id
+  ) AS cases_count,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      case_parties
+      JOIN court_cases ON case_parties.court_case_id = court_cases.id
+      JOIN case_types ON case_types.id = court_cases.case_type_id
+    WHERE
+      party_id = parties.id
+      AND case_types.abbreviation = 'CF'
+  ) AS cf_count,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      case_parties
+      JOIN court_cases ON case_parties.court_case_id = court_cases.id
+      JOIN case_types ON case_types.id = court_cases.case_type_id
+    WHERE
+      party_id = parties.id
+      AND case_types.abbreviation = 'CM'
+  ) AS cm_count,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      docket_events
+      JOIN docket_event_types ON docket_events.docket_event_type_id = docket_event_types.id
+    WHERE
+      docket_events.party_id = parties.id
+      AND docket_event_types.code IN(
+        'WAI$',
+        'BWIFAP',
+        'BWIFA',
+        'BWIFC',
+        'BWIAR',
+        'BWIAA',
+        'BWICA',
+        'BWIFAR',
+        'BWIFAA',
+        'BWIFP',
+        'BWIMW',
+        'BWIR8',
+        'BWIS',
+        'BWIS$',
+        'WAI',
+        'WAIMV',
+        'WAIMW',
+        'BWIFAR'
+      )
+  ) AS warrants_count,
+  (
+    SELECT
+      SUM(amount)
+    FROM
+      docket_events
+    WHERE
+      docket_events.party_id = parties.id
+  ) AS total_fined,
+  (
+    SELECT
+      SUM(payment)
+    FROM
+      docket_events
+    WHERE
+      docket_events.party_id = parties.id
+  ) AS total_paid,
+  (
+    SELECT
+      SUM(adjustment)
+    FROM
+      docket_events
+    WHERE
+      docket_events.party_id = parties.id
+  ) AS total_adjusted,
+  (
+    (
+      SELECT
+        SUM(amount)
+      FROM
+        docket_events
+      WHERE
+        docket_events.party_id = parties.id
+    ) - (
+      SELECT
+        SUM(payment)
+      FROM
+        docket_events
+      WHERE
+        docket_events.party_id = parties.id
+    ) - (
+      SELECT
+        SUM(adjustment)
+      FROM
+        docket_events
+      WHERE
+        docket_events.party_id = parties.id
+    )
+  ) AS account_balance
+FROM
+  parties
+  JOIN party_types on parties.party_type_id = party_types.id
+WHERE
+  party_types.name = 'defendant'


### PR DESCRIPTION
# Description

Adds views for summary level information summarized at the `cases` and `parties` level. These can be used for historical calculations where the full data set is taken into account. Entity resolution will help to make the parties more accurate since there are many duplicate parties on OSCN.