### PR TITLE
Create sidekiq queues and extract days variable to env

### DIFF
--- a/app/services/scrapers/case.rb
+++ b/app/services/scrapers/case.rb
@@ -9,8 +9,8 @@ module Scrapers
     def perform
       # TODO: Capture results and send via email or slack message
       counties.each do |county|
-        Scrapers::NewCases.perform(county, days_ago: 7)
-        Scrapers::HighPriority.perform(county, days_ago: 7, days_forward: 7)
+        Scrapers::NewCases.perform(county, days_ago: days_ago)
+        Scrapers::HighPriority.perform(county, days_ago: days_ago, days_forward: days_forward)
       end
 
       Scrapers::MediumPriority.perform
@@ -19,6 +19,14 @@ module Scrapers
 
     def counties
       ENV['COUNTIES'].split(',') # TODO: Change to ENV variable
+    end
+
+    def days_ago
+      ENV.fetch('DAYS_AGO', 7).to_i
+    end
+
+    def days_forward
+      ENV.fetch('DAYS_FORWARD', 7).to_i
     end
   end
 end

--- a/app/services/scrapers/high_priority.rb
+++ b/app/services/scrapers/high_priority.rb
@@ -17,10 +17,12 @@ module Scrapers
       cases = fetch_case_list
 
       bar = ProgressBar.new(cases.count)
-      puts "#{cases.count} are high priority for update"
+      puts "#{cases.count} are high priority for update for #{county.name} county"
 
       cases.each do |case_number|
-        CourtCaseWorker.perform_async({ county_id: @county.id, case_number: case_number, scrape_case: true })
+        CourtCaseWorker
+          .set(queue: :high)
+          .perform_async({ county_id: @county.id, case_number: case_number, scrape_case: true })
         bar.increment!
       end
     end

--- a/app/services/scrapers/low_priority.rb
+++ b/app/services/scrapers/low_priority.rb
@@ -7,7 +7,7 @@ module Scrapers
       @cases = CourtCase.closed.older_than(days_ago.days.ago).limit(limit)
     end
 
-    def self.perform(days_ago: 90, limit: 2500)
+    def self.perform(days_ago: 90, limit: 7500)
       new(days_ago: days_ago, limit: limit).perform
     end
 
@@ -16,7 +16,9 @@ module Scrapers
       bar = ProgressBar.new(cases.count)
 
       cases.each do |c|
-        CourtCaseWorker.perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
+        CourtCaseWorker
+          .set(queue: :low)
+          .perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
         bar.increment!
       end
     end

--- a/app/services/scrapers/medium_priority.rb
+++ b/app/services/scrapers/medium_priority.rb
@@ -17,7 +17,9 @@ module Scrapers
       bar = ProgressBar.new(cases.count)
 
       cases.each do |c|
-        CourtCaseWorker.perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
+        CourtCaseWorker
+          .set(queue: :medium)
+          .perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
         bar.increment!
       end
     end

--- a/app/workers/court_case_worker.rb
+++ b/app/workers/court_case_worker.rb
@@ -4,7 +4,7 @@ require 'importers/court_case'
 class CourtCaseWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Worker
-  sidekiq_options retry: 5
+  sidekiq_options retry: 5, queue: :medium
   sidekiq_throttle_as :oscn
 
   def perform(args)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,5 @@
 :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 5 %>
 :queues:
-  - critical
   - high
   - medium
   - default


### PR DESCRIPTION
# Description

Adds two new ENV variables that can be configure to fine tune the desired refresh rate for the scraper.

`DAYS_AGO` - Number of days that have past since a case has been on the docket. 
`DAYS_FORWARD` - Looks at the cases on the docket for the upcoming x days.

Both are used to define cases that are high priority to re-scrape.