### PR TITLE
Add env variables for low and medium priority scraping

### DIFF
--- a/app/services/scrapers/case.rb
+++ b/app/services/scrapers/case.rb
@@ -18,7 +18,7 @@ module Scrapers
     end
 
     def counties
-      ENV['COUNTIES'].split(',') # TODO: Change to ENV variable
+      ENV['COUNTIES'].split(',')
     end
 
     def days_ago

--- a/app/services/scrapers/low_priority.rb
+++ b/app/services/scrapers/low_priority.rb
@@ -3,12 +3,12 @@ module Scrapers
   class LowPriority
     attr_accessor :cases
 
-    def initialize(days_ago: 90, limit: 7500)
+    def initialize(days_ago: 90, limit: low_count)
       @cases = CourtCase.closed.older_than(days_ago.days.ago).limit(limit)
     end
 
-    def self.perform(days_ago: 90, limit: 7500)
-      new(days_ago: days_ago, limit: limit).perform
+    def self.perform(days_ago: 90)
+      new(days_ago: days_ago).perform
     end
 
     def perform
@@ -21,6 +21,12 @@ module Scrapers
           .perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
         bar.increment!
       end
+    end
+
+    private
+
+    def low_count
+      ENV.fetch('LOW_PRIORITY', 10000).to_i
     end
   end
 end

--- a/app/services/scrapers/medium_priority.rb
+++ b/app/services/scrapers/medium_priority.rb
@@ -3,7 +3,7 @@ module Scrapers
   class MediumPriority
     attr_accessor :cases, :days_ago
 
-    def initialize(days_ago: 14, limit: 7500)
+    def initialize(days_ago: 14, limit: medium_count)
       @days_ago = days_ago
       @cases = CourtCase.active.older_than(14.days.ago).limit(limit)
     end
@@ -22,6 +22,12 @@ module Scrapers
           .perform_async({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
         bar.increment!
       end
+    end
+
+    private
+
+    def medium_count
+      ENV.fetch('MEDIUM_PRIORITY', 10000).to_i
     end
   end
 end


### PR DESCRIPTION
# Description

Adds two new ENV variables

`LOW_PRIORITY` - Number of low priority cases to scrape nightly
`MEDIUM_PRIORITY` - Number of medium priority cases to scrape nightly

These can be used to fine tune the scraper for the refresh rate that you desire