### PR TITLE
Remove comma before float conversion

### DIFF
--- a/app/services/importers/docket_events/fee.rb
+++ b/app/services/importers/docket_events/fee.rb
@@ -32,7 +32,7 @@ module Importers
         payment = regex.match(docket_event_data[:description])
         return 0 if payment.nil?
 
-        amount = payment[1].to_f
+        amount = payment[1].gsub(',','').to_f
 
         if amount.zero?
           intercept_regex = /#{case_number}:\s*?\$-*?(\d|,)+\.\d{2}/


### PR DESCRIPTION
# Description

Commas in the dollar amounts were causing issues when it was converted to a float.

**Previously**

$2,500 was returning 2

Now it correctly returns 2500