### PR TITLE
WIP:  Potential Solution to Issue #56 : Unsafe JSON Serialization 

### DIFF
--- a/app/services/scrapers/high_priority.rb
+++ b/app/services/scrapers/high_priority.rb
@@ -19,10 +19,7 @@ module Scrapers
       bar = ProgressBar.new(cases.count)
       puts "#{cases.count} are high priority for update for #{county.name} county"
 
-
-
       cases.each do |case_number|
-        
         worker_args = JSON.dump({ county_id: @county.id, case_number: case_number, scrape_case: true })
         CourtCaseWorker
           .set(queue: :high)

--- a/app/services/scrapers/low_priority.rb
+++ b/app/services/scrapers/low_priority.rb
@@ -15,7 +15,7 @@ module Scrapers
       puts "Pulling #{cases.count} low priority cases"
       bar = ProgressBar.new(cases.count)
 
-      cases.each do |c|
+      cases.each do |_c|
         worker_args = JSON.dump({ county_id: @county.id, case_number: case_number, scrape_case: true })
 
         CourtCaseWorker

--- a/app/services/scrapers/medium_priority.rb
+++ b/app/services/scrapers/medium_priority.rb
@@ -17,7 +17,7 @@ module Scrapers
       bar = ProgressBar.new(cases.count)
 
       cases.each do |c|
-        worker_args =JSON.dump({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
+        worker_args = JSON.dump({ county_id: c.county_id, case_number: c.case_number, scrape_case: true })
         CourtCaseWorker
           .set(queue: :medium)
           .perform_async(worker_args)


### PR DESCRIPTION
**Description**

Solves #56 
added new worker_arg variable that serialize the arguments using JSON.dump

**How to Test**

Run `rails console` in terminal

create variable `worker_args = JSON.dump({ county_id: 55, case_number: 'CF-2021-124', scrape_case: false })`

run command:   `CourtCaseWorker.set(queue: :default).perform_async(worker_args)`

You will note that the warning mentioned in issue#56 (Sidekiq warning for CourtCaseWorker JSON serialization) is gone. only the CannotConnectError remains.