### PR TITLE
Limit the recent cases scraper to county

### DIFF
--- a/app/services/scrapers/recent_cases.rb
+++ b/app/services/scrapers/recent_cases.rb
@@ -7,7 +7,7 @@ module Scrapers
     def initialize(county, days_ago, days_forward)
       @case_changes = OscnScraper::Parsers::CaseChanges
       @county = county
-      @court_cases = CourtCase.pluck(:case_number, :oscn_id).to_h
+      @court_cases = CourtCase.for_county_name(county).pluck(:case_number, :oscn_id).to_h
       @case_types = CaseType.active
       @recent_cases = []
       @days_ago = days_ago


### PR DESCRIPTION
# Description

This limits the `court_cases` hash in `Scrapers::RecentCases` to the county. This should help with memory issues while we wait for Heroku to give access to larger dynos